### PR TITLE
Document GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ CSE 110 - Spring 2026
 
 ## GitHub Pages URL
 
-https://salwazir.github.io/sp26-cse110-lab3/
+Live at: https://salwazir.github.io/sp26-cse110-lab3/
+
+Status: built and served over HTTPS from `main` branch (root).
 
 ## Overview
 


### PR DESCRIPTION
Closes #1

Confirms the Pages URL is live and documents deployment status in README.